### PR TITLE
sing-box-ref1nd: enable naive outbound

### DIFF
--- a/Formula/sing-box-ref1nd.rb
+++ b/Formula/sing-box-ref1nd.rb
@@ -5,6 +5,7 @@ class SingBoxRef1nd < Formula
   version "1.14.0-alpha.21-reF1nd"
   sha256 "5fdc43326a9063c4ddfa573c9757c31d88cbc4bc0b478f6117b66f5a859a0085"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://github.com/reF1nd/sing-box.git", branch: "reF1nd-dev-next"
 
   livecheck do
@@ -12,22 +13,27 @@ class SingBoxRef1nd < Formula
     regex(/^v(\d(?:\.\d+)+(-\w+(?:\.\d+)?)?-reF1nd(?:\.\d+)?)$/i)
   end
 
-  bottle do
-    root_url "https://ghcr.io/v2/moonfruit/bottle"
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:  "5e71d490112ba2602d8e2aad5225d4b716a17e1a4ba29c5cdcd1d6c5dc98accd"
-    sha256 cellar: :any_skip_relocation, arm64_linux:  "f94809cebad32b2394dffa5334c3e564bfacde97e82545e085c04a71aefe4f86"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "98a19d24fd2aa35b2715e06e14063b507e81ab86f378b9c53c077ca7df273b31"
-  end
-
   keg_only :versioned_formula
 
   depends_on "go" => :build
 
+  on_linux do
+    depends_on "lld" => :build
+    depends_on "llvm" => :build
+  end
+
   def install
-    ldflags = "-X github.com/sagernet/sing-box/constant.Version=#{version} " \
-              "#{(buildpath/"release/LDFLAGS").read.strip} -s -w -buildid="
-    tags = (buildpath/"release/DEFAULT_BUILD_TAGS_OTHERS").read.strip
+    tags = File.read("release/DEFAULT_BUILD_TAGS").strip.split(",")
+    ldflags_shared = File.read("release/LDFLAGS").strip
+
+    if OS.linux?
+      ENV["CC"] = Formula["llvm"].opt_bin/"clang"
+      ENV["CXX"] = Formula["llvm"].opt_bin/"clang++"
+      ENV["CGO_ENABLED"] = "1"
+      ENV["CGO_LDFLAGS"] = "-fuse-ld=#{Formula["lld"].opt_bin}/ld.lld"
+    end
+
+    ldflags = "-s -w -X github.com/sagernet/sing-box/constant.Version=#{version} #{ldflags_shared} -buildid="
     system "go", "build", *std_go_args(ldflags:, output: bin/"sing-box", tags:), "./cmd/sing-box"
     generate_completions_from_executable(bin/"sing-box", shell_parameter_format: :cobra)
   end
@@ -53,7 +59,7 @@ class SingBoxRef1nd < Formula
         ]
       }
     JSON
-    server = fork { exec bin/"sing-box", "run", "-D", testpath, "-c", testpath/"shadowsocks.json" }
+    server = spawn bin/"sing-box", "run", "-D", testpath, "-c", testpath/"shadowsocks.json"
 
     sing_box_port = free_port
     (testpath/"config.json").write <<~JSON
@@ -77,15 +83,15 @@ class SingBoxRef1nd < Formula
       }
     JSON
     system bin/"sing-box", "check", "-D", testpath, "-c", "config.json"
-    client = fork { exec bin/"sing-box", "run", "-D", testpath, "-c", "config.json" }
+    client = spawn bin/"sing-box", "run", "-D", testpath, "-c", "config.json"
 
-    sleep 3
     begin
+      sleep 3
       system "curl", "--socks5", "127.0.0.1:#{sing_box_port}", "github.com"
     ensure
-      Process.kill 9, server
+      Process.kill "TERM", server
+      Process.kill "TERM", client
       Process.wait server
-      Process.kill 9, client
       Process.wait client
     end
   end


### PR DESCRIPTION
对齐 [homebrew-core 的 `sing-box.rb`](https://github.com/Homebrew/homebrew-core/blob/main/Formula/s/sing-box.rb) 写法，启用 `with_naive_outbound`：

- 改用 `release/DEFAULT_BUILD_TAGS`（含 `with_naive_outbound`），上游 macOS 与 Linux 官方构建均使用此 tag。
- macOS：原生 cgo + 系统 clang 即可，`libcronet.a` 已由 `cronet-go/lib/darwin_*` 子模块预编译并随 `go.mod` 间接拉入。
- Linux：新增 `llvm` / `lld` 构建依赖，`CC=clang`、`CXX=clang++`、`CGO_ENABLED=1`、`CGO_LDFLAGS=-fuse-ld=ld.lld`。
- `test` 同步切换为 `spawn` + `Process.kill "TERM"`，与 homebrew-core 保持一致。
- `revision 1`，旧 bottle 已失效，由 pr-pull 工作流回填新 bottle SHA。