### PR TITLE
gotools 1.0.0

### DIFF
--- a/Formula/gotools.rb
+++ b/Formula/gotools.rb
@@ -1,0 +1,28 @@
+class Gotools < Formula
+  desc "Monorepo of small Go command-line utilities"
+  homepage "https://github.com/moonfruit/gotools"
+  url "https://github.com/moonfruit/gotools/archive/refs/tags/v1.0.0.tar.gz"
+  sha256 "7504472c1dd1da0400bb3c690544b6393cb5dd19bc314a128195d098c4711670"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    Dir["cmd/*"].each do |dir|
+      next unless File.directory?(dir)
+
+      name = File.basename(dir)
+      system "go", "build", *std_go_args(output: bin/name, ldflags: "-s -w"), "./#{dir}"
+      generate_completions_from_executable(bin/name, shell_parameter_format: :cobra)
+    end
+  end
+
+  test do
+    input = "bob@example.com\nalice@1.1.1.1\nadmin@[::1]:22\n"
+    expected = "alice@1.1.1.1\nadmin@[::1]:22\nbob@example.com\n"
+    assert_equal expected, pipe_output(bin/"uhsort", input, 0)
+
+    expected_count = "2\ta@h\n1\tb@h\n"
+    assert_equal expected_count, pipe_output("#{bin}/uhsort -c", "a@h\na@h\nb@h\n", 0)
+  end
+end


### PR DESCRIPTION
Add `gotools` 1.0.0 — a monorepo of small Go command-line utilities.

Currently ships:

- `uhsort` — sort `user@host[:port]` lists by host (IPv4 < IPv6 < domain) → port → user → rest, with `-u` dedupe and `-c` count; supports stdin/stdout, `-o`, and `-i` in-place edit.

The formula auto-discovers tools under `cmd/*`, so future tools added upstream require only a version/sha bump here.

## Test plan
- [x] `brew style Formula/gotools.rb`
- [x] `brew audit --new --formula moonfruit/tap/gotools`
- [x] `brew install --build-from-source Formula/gotools.rb`
- [x] `brew test moonfruit/tap/gotools`