### PR TITLE
docs: expand CLAUDE.md guidance and refresh README listings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,38 +10,122 @@ This is a personal Homebrew third-party tap (`moonfruit/tap`) containing Formula
 
 - `Formula/` — Homebrew formula definitions (Ruby classes inheriting `Formula`)
 - `Casks/` — Homebrew cask definitions (for GUI apps and fonts)
-- `audit_exceptions/` — JSON files for suppressing specific `brew audit` warnings
+- `audit_exceptions/` — JSON files suppressing specific `brew audit` warnings
+  - `github_prerelease_allowlist.json` — JSON array of formula/cask names allowed to track prereleases
+  - `flat_namespace_allowlist.json` — JSON object `{ "<name>": "any" | ["dylib", ...] }` for casks with non-relocatable Mach-O
+
+## Reference Implementations
+
+When writing or fixing formulae/casks, consult real examples in the official taps before guessing:
+
+- **Formula 实现样例**：`$(brew --prefix)/Library/Taps/homebrew/homebrew-core/Formula/`
+  - 按首字母分子目录，例如 `Formula/g/go.rb`、`Formula/o/openssl@3.rb`
+  - Go 项目模式参考 `gh.rb`、`fzf.rb`；带 service 的参考 `redis.rb`、`postgresql@*.rb`；keg_only 版本化参考 `openssl@3.rb`、`python@3.*.rb`
+- **Cask 实现样例**：`$(brew --prefix)/Library/Taps/homebrew/homebrew-cask/Casks/`
+  - 同样按首字母分子目录，字体在 `Casks/font/font-*/`，例如 `font/font-j/font-jetbrains-mono.rb`
+  - `pkg` 安装参考已有的 `*.pkg` cask；带 `quit`/`login_item`/`pkgutil` uninstall 的样例多见于 `Casks/s/`
+- **brew 自身行为/DSL 定义**：`$(brew --prefix)/Library/Homebrew/`
+  - Formula DSL：`formula.rb`、`formula_installer.rb`
+  - Cask DSL：`cask/dsl.rb`、`cask/artifact/*.rb`（`pkg.rb`、`app.rb`、`zap.rb` 等）
+  - Livecheck 策略：`livecheck/strategy/*.rb`
+  - Audit 规则：`formula_auditor.rb`、`cask/audit.rb`（用于理解 audit 报错根因）
+  - 直接 `rg` 搜索符号，例如 `rg "def std_go_args" $(brew --prefix)/Library/Homebrew`
+
+不要把这些路径用 Write 写改——它们是只读的官方代码，只用 Read/Grep 查阅。
 
 ## Common Commands
 
 ```bash
-# Audit a formula or cask for style/correctness issues
+# Audit
 brew audit --tap moonfruit/tap
 brew audit --formula moonfruit/tap/<name>
 brew audit --cask moonfruit/tap/<name>
+brew audit --new moonfruit/tap/<name>          # stricter rules for first submission
 
-# Style check (RuboCop)
-brew style moonfruit/tap
-brew style Formula/<name>.rb
+# Style (RuboCop) — fix is safe
+brew style --fix moonfruit/tap
+brew style --fix Formula/<name>.rb
 
-# Test a formula
+# Test
 brew test moonfruit/tap/<name>
+
+# Livecheck — verify upstream regex
+brew livecheck moonfruit/tap/<name>
+brew livecheck --tap moonfruit/tap
 
 # Install from local source
 brew install --build-from-source Formula/<name>.rb
 
-# Build bottles (precompiled binaries)
-brew install --build-bottle Formula/<name>.rb
-brew bottle --root-url "https://ghcr.io/v2/moonfruit/bottle" <name>
+# Bump helpers
+brew bump-formula-pr --no-fork --no-browse --tap moonfruit/tap <name>
+brew bump-cask-pr   --no-fork --no-browse --tap moonfruit/tap <name>
 ```
 
 ## Bottle Hosting
 
-Bottles are hosted on GitHub Container Registry under `ghcr.io/v2/moonfruit/bottle`. When updating bottle blocks, use this `root_url`.
+Bottles are hosted on GitHub Container Registry under `ghcr.io/v2/moonfruit/bottle` 并由线上 CI 构建发布，**不要在本地手工跑 `brew bottle`**。线上 `pr-pull` 流程会自动产出多平台 bottle 并把 `sha256` 行回写进 Formula。
 
 ## Formula Conventions
 
-- Formulas that conflict with official Homebrew packages use `keg_only :versioned_formula` (e.g., `sing-box-beta`, `openssl@1.0`)
-- Go-based formulas use `depends_on "go" => :build` and `std_go_args`
-- `livecheck` blocks are used to track upstream releases
-- Service blocks define `brew services` integration where applicable
+- Versioned/conflicting formulae use `keg_only :versioned_formula` (see `openssl@1.0.rb`, `sing-box-beta.rb`, `gwt@2.*`)
+- Go formulae use `depends_on "go" => :build` + `std_go_args(output: ..., ldflags: "-s -w")`；多命令仓库循环编译 `cmd/*`（见 `gotools.rb`）
+- `livecheck do ... end` 必备；`regex(...)` 参考 homebrew-core 同类项目
+- `service do` 块用于 `brew services`（见 `sing-box-beta.rb`、`sing-box-ref1nd.rb`）
+- 不手工编辑 `bottle do` 块 — 由线上 CI 在 `pr-pull` 阶段写入
+
+## Cask Conventions
+
+- 双架构以 `arch arm: "...", intel: "..."` + `sha256 arm:, intel:` 表达；URL 中用 `#{arch}`
+- 字体 Cask 命名为 `font-*`，参考 `Casks/font-source-han-*`、`Casks/font-pinyin-*`
+- `.pkg` 安装必须配 `uninstall pkgutil:`；带后台进程再加 `quit:`，登录项加 `login_item:`（见 `sfm@alpha.rb`）
+- `zap trash: [...]` 列出 `~/Library/...` 残留路径
+- `verified:` 用于非 GitHub releases 域或自定义 URL；`url "..." , verified: "github.com/<org>/<repo>/"` 是常见写法
+
+## Pre-commit Checklist
+
+提交前对改动文件依次跑：
+
+```bash
+brew style --fix moonfruit/tap/<name>
+brew audit --strict --online moonfruit/tap/<name>
+brew livecheck moonfruit/tap/<name>      # 如改了 livecheck 或版本
+brew test moonfruit/tap/<name>           # formula 才有
+```
+
+## Release Workflow
+
+### PR 与提交粒度
+
+- **一个 PR 默认只动一个 formula 或 cask**；只在有强相关性时才允许多个，例如：
+  - 依赖链一起升：`tongsuo` 与依赖它的 `tscurl`
+  - 同一软件的多个版本/配置：`gwt@2.4`/`gwt@2.5`/`gwt@2.6`/`gwt@2.7`、`wlp-webprofile8` 与 `wlp-webprofile10`
+- **每个 formula / cask 在 PR 内保持单一提交**：一个 PR 里如果同时改了 N 个 formula/cask，就有且只有 N 个提交，每个提交只动一个文件（外加可能的 `audit_exceptions/` 同步修改）
+- 多次返工用 `git commit --amend`（单提交时）或 `git rebase -i`（多提交时挑对应提交 squash），再 `git push --force-with-lease`
+- 提交消息：单升级写 `<name> <version>`；其它修改写 `<name>: <change>`
+
+### Formula 升级 / 新增
+
+线上 CI 负责构建 bottle，所以 Formula 走 `pr-pull` 流程：
+
+1. 改 Formula（版本号、`url`、`sha256`、依赖等）
+2. `git commit`（每个 formula 一个提交）
+3. 返工时按上节规则 squash，保持每个 formula 仍是单一提交
+4. `git push`（首次）或 `git push --force-with-lease`（amend/rebase 后）
+5. 开 PR，等待 CI 完成 audit/test 与多平台 bottle 构建
+6. Review 通过后给 PR 打上 `pr-pull` 标签
+7. CI 检测到 `pr-pull` 标签，自动把 bottle 上传到 `ghcr.io/v2/moonfruit/bottle`，把 `sha256` 行回写进对应 Formula 并合并 PR
+
+### Cask 升级 / 新增
+
+Cask 不产 bottle，流程更短：
+
+1. 改 Cask（`version`、`sha256`、URL、`uninstall`/`zap` 等）
+2. `git commit`（每个 cask 一个提交）
+3. 返工时 squash，保持每个 cask 单一提交
+4. `git push` 或 `git push --force-with-lease`
+5. 开 PR，等待 CI 完成 audit
+6. Review 通过后直接合并 PR（无需 `pr-pull` 标签）
+
+### 同 PR 内 Formula + Cask 混合
+
+只有在强相关时才这样做；这种 PR 仍按 Formula 流程走 `pr-pull`（因为有 Formula 需要回写 bottle sha256），不要为了 Cask 的"直接合并"流程把它从 PR 里拆出去。

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ brew install moonfruit/tap/<formula>
 brew install --cask moonfruit/tap/<cask>
 ```
 
+### Update / Uninstall
+
+```bash
+brew update && brew upgrade
+brew uninstall moonfruit/tap/<formula>
+brew untap moonfruit/tap        # remove the tap entirely
+```
+
 ## 🍺 Formula List
 
 ### Applications & Tools
@@ -42,23 +50,53 @@ brew install --cask moonfruit/tap/<cask>
 - **Repository**: [sirmalloc/ccstatusline](https://github.com/sirmalloc/ccstatusline)
 - **Description**: Status line formatter for Claude Code
 
-#### 🌐 sing-box@beta
+#### 🌐 sing-box-beta
 
 - **Homepage**: [sing-box](https://sing-box.sagernet.org/)
 - **Repository**: [SagerNet/sing-box](https://github.com/SagerNet/sing-box)
 - **Description**: Universal proxy platform supporting multiple protocols for network proxying (beta/alpha)
 
-#### 🌐 sing-box@ref1nd
+#### 🌐 sing-box-ref1nd
 
 - **Homepage**: [sing-box reF1nd](https://sing-boxr.dustinwin.us.kg/)
 - **Repository**: [reF1nd/sing-box](https://github.com/reF1nd/sing-box)
 - **Description**: Universal proxy platform supporting multiple protocols for network proxying (reF1nd variant)
+
+#### 🪵 sing2seq
+
+- **Homepage**: [sing2seq](https://github.com/moonfruit/sing2seq)
+- **Repository**: [moonfruit/sing2seq](https://github.com/moonfruit/sing2seq)
+- **Description**: Transporter that forwards sing-box logs to a Seq server
+
+#### 🪵 seqcli
+
+- **Homepage**: [Seq](https://datalust.co/seq)
+- **Repository**: [datalust/seqcli](https://github.com/datalust/seqcli)
+- **Description**: Command-line client for Seq structured logging
 
 #### 🗺️ geo
 
 - **Homepage**: [geo](https://github.com/MetaCubeX/geo)
 - **Repository**: [MetaCubeX/geo](https://github.com/MetaCubeX/geo)
 - **Description**: Geographic resource manager for managing IP geolocation databases and routing rules
+
+#### 🌐 ethr
+
+- **Homepage**: [ethr](https://github.com/microsoft/ethr)
+- **Repository**: [microsoft/ethr](https://github.com/microsoft/ethr)
+- **Description**: Comprehensive network measurement tool supporting TCP, UDP, and ICMP protocols
+
+#### 💬 wecom-cli
+
+- **Homepage**: [wecom-cli](https://github.com/WecomTeam/wecom-cli)
+- **Repository**: [WecomTeam/wecom-cli](https://github.com/WecomTeam/wecom-cli)
+- **Description**: Command-line client for WeCom (WeChat Work)
+
+#### ✍️ inkos
+
+- **Homepage**: [inkos](https://github.com/Narcooo/inkos)
+- **Repository**: [Narcooo/inkos](https://github.com/Narcooo/inkos)
+- **Description**: Autonomous novel-writing CLI AI agent
 
 ### Programming Tools
 
@@ -79,6 +117,18 @@ brew install --cask moonfruit/tap/<cask>
 - **Homepage**: [lzc-cli](https://www.npmjs.com/package/@lazycatcloud/lzc-cli)
 - **Repository**: N/A
 - **Description**: Lazycat hardware client tool
+
+#### 🐹 gotools
+
+- **Homepage**: [gotools](https://github.com/moonfruit/gotools)
+- **Repository**: [moonfruit/gotools](https://github.com/moonfruit/gotools)
+- **Description**: Monorepo of small Go command-line utilities
+
+#### ☕ gwt@2.4 / gwt@2.5 / gwt@2.6 / gwt@2.7
+
+- **Homepage**: [GWT Project](https://www.gwtproject.org/)
+- **Repository**: [gwtproject/gwt](https://github.com/gwtproject/gwt)
+- **Description**: Google Web Toolkit (versioned, keg-only). Pick the version matching the Java/legacy project you need
 
 ### Security & Encryption
 
@@ -180,12 +230,6 @@ brew install --cask moonfruit/tap/<cask>
 - **Repository**: N/A
 - **Description**: cURL tool with TLCP support
 
-#### 🌐 ethr
-
-- **Homepage**: [ethr](https://github.com/microsoft/ethr)
-- **Repository**: [microsoft/ethr](https://github.com/microsoft/ethr)
-- **Description**: Comprehensive network measurement tool supporting TCP, UDP, and ICMP protocols
-
 #### 🖨️ canon-mf-ufr2-printer
 
 - **Homepage**: [Canon Support](https://hk.canon/en/support)
@@ -209,6 +253,12 @@ brew install --cask moonfruit/tap/<cask>
 - **Homepage**: [SFM alpha](https://sing-box.sagernet.org/)
 - **Repository**: [SagerNet/sing-box](https://github.com/SagerNet/sing-box)
 - **Description**: Standalone client for sing-box, the universal proxy platform
+
+#### 🔀 rebased
+
+- **Homepage**: [rebased](https://github.com/DetachHead/rebased)
+- **Repository**: [DetachHead/rebased](https://github.com/DetachHead/rebased)
+- **Description**: JetBrains-based Git client
 
 ### Fonts
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -18,6 +18,14 @@ brew install moonfruit/tap/<formula>
 brew install --cask moonfruit/tap/<cask>
 ```
 
+### 更新 / 卸载
+
+```bash
+brew update && brew upgrade
+brew uninstall moonfruit/tap/<formula>
+brew untap moonfruit/tap        # 完全移除 tap
+```
+
 ## 🍺 Formula 列表
 
 ### 应用与工具
@@ -40,23 +48,53 @@ brew install --cask moonfruit/tap/<cask>
 - **仓库**：[sirmalloc/ccstatusline](https://github.com/sirmalloc/ccstatusline)
 - **简介**：Claude Code 状态行格式化工具
 
-#### 🌐 sing-box@beta
+#### 🌐 sing-box-beta
 
 - **主页**：[sing-box](https://sing-box.sagernet.org/)
 - **仓库**：[SagerNet/sing-box](https://github.com/SagerNet/sing-box)
 - **简介**：通用代理平台，支持多种协议的网络代理工具 (beta/alpha)
 
-#### 🌐 sing-box@ref1nd
+#### 🌐 sing-box-ref1nd
 
 - **主页**：[sing-box reF1nd](https://sing-boxr.dustinwin.us.kg/)
 - **仓库**：[reF1nd/sing-box](https://github.com/reF1nd/sing-box)
 - **简介**：通用代理平台，支持多种协议的网络代理工具 (reF1nd 变种)
+
+#### 🪵 sing2seq
+
+- **主页**：[sing2seq](https://github.com/moonfruit/sing2seq)
+- **仓库**：[moonfruit/sing2seq](https://github.com/moonfruit/sing2seq)
+- **简介**：将 sing-box 日志转发到 Seq 服务器的中转工具
+
+#### 🪵 seqcli
+
+- **主页**：[Seq](https://datalust.co/seq)
+- **仓库**：[datalust/seqcli](https://github.com/datalust/seqcli)
+- **简介**：Seq 结构化日志服务的命令行客户端
 
 #### 🗺️ geo
 
 - **主页**： [geo](https://github.com/MetaCubeX/geo)
 - **仓库**：[MetaCubeX/geo](https://github.com/MetaCubeX/geo)
 - **简介**：地理位置资源管理器，用于管理 IP 地理数据库和路由规则
+
+#### 🌐 ethr
+
+- **主页**：[ethr](https://github.com/microsoft/ethr)
+- **仓库**：[microsoft/ethr](https://github.com/microsoft/ethr)
+- **简介**：综合网络测量工具，支持 TCP、UDP 和 ICMP 协议
+
+#### 💬 wecom-cli
+
+- **主页**：[wecom-cli](https://github.com/WecomTeam/wecom-cli)
+- **仓库**：[WecomTeam/wecom-cli](https://github.com/WecomTeam/wecom-cli)
+- **简介**：企业微信 (WeCom) 命令行客户端
+
+#### ✍️ inkos
+
+- **主页**：[inkos](https://github.com/Narcooo/inkos)
+- **仓库**：[Narcooo/inkos](https://github.com/Narcooo/inkos)
+- **简介**：自主写小说的 CLI AI Agent
 
 ### 编程工具
 
@@ -77,6 +115,18 @@ brew install --cask moonfruit/tap/<cask>
 - **主页**：[lzc-cli](https://www.npmjs.com/package/@lazycatcloud/lzc-cli)
 - **仓库**：N/A
 - **简介**：Lazycat 硬件客户端工具
+
+#### 🐹 gotools
+
+- **主页**：[gotools](https://github.com/moonfruit/gotools)
+- **仓库**：[moonfruit/gotools](https://github.com/moonfruit/gotools)
+- **简介**：一组小型 Go 命令行工具的 monorepo
+
+#### ☕ gwt@2.4 / gwt@2.5 / gwt@2.6 / gwt@2.7
+
+- **主页**：[GWT Project](https://www.gwtproject.org/)
+- **仓库**：[gwtproject/gwt](https://github.com/gwtproject/gwt)
+- **简介**：Google Web Toolkit（多版本并存，keg-only），按所需的旧 Java 项目挑选对应版本
 
 ### 安全与加密
 
@@ -178,15 +228,9 @@ brew install --cask moonfruit/tap/<cask>
 - **仓库**：N/A
 - **简介**：支持 TLCP 的 cURL 工具
 
-#### 🌐 ethr
-
-- **主页**：[ethr](https://github.com/microsoft/ethr)
-- **仓库**：[microsoft/ethr](https://github.com/microsoft/ethr)
-- **简介**：综合网络测量工具，支持 TCP、UDP 和 ICMP 协议
-
 #### 🖨️ canon-mf-ufr2-printer
 
-- **主页**：[Cannon Support](https://hk.canon/en/support)
+- **主页**：[Canon Support](https://hk.canon/en/support)
 - **仓库**：N/A
 - **简介**：Canon imageCLASS MF 系列打印机的 UFRII/UFRII LT 驱动程序和实用工具
 
@@ -207,6 +251,12 @@ brew install --cask moonfruit/tap/<cask>
 - **主页**：[SFM alpha](https://sing-box.sagernet.org/)
 - **仓库**：[SagerNet/sing-box](https://github.com/SagerNet/sing-box)
 - **简介**：sing-box 通用代理平台的独立客户端
+
+#### 🔀 rebased
+
+- **主页**：[rebased](https://github.com/DetachHead/rebased)
+- **仓库**：[DetachHead/rebased](https://github.com/DetachHead/rebased)
+- **简介**：基于 JetBrains IDE 的 Git 客户端
 
 ### 字体
 


### PR DESCRIPTION
## Summary
- Expand CLAUDE.md with reference implementation paths, cask conventions, pre-commit checklist, and full release workflow
- Refresh README.md / README_zh.md to match current formula/cask roster (sing-box rename, new entries, section reorg)
- Fix Canon typo in README_zh.md

## Test plan
- [x] No code changes; docs only