### PR TITLE
officecli 1.0.89

### DIFF
--- a/Formula/officecli.rb
+++ b/Formula/officecli.rb
@@ -1,0 +1,44 @@
+class Officecli < Formula
+  desc "AI-friendly CLI for Office documents (.docx, .xlsx, .pptx)"
+  homepage "https://officecli.ai"
+  url "https://github.com/iOfficeAI/OfficeCLI/archive/refs/tags/v1.0.89.tar.gz"
+  sha256 "900d264455339660b0de9b809a664373cfd1961ea9ca87fa93aed71fa210dbe8"
+  license "Apache-2.0"
+
+  depends_on "dotnet" => :build
+  depends_on "brotli"
+
+  on_linux do
+    depends_on "icu4c@78"
+    depends_on "openssl@3"
+  end
+
+  def install
+    ENV["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1"
+
+    arch = Hardware::CPU.arm? ? "arm64" : "x64"
+    os = OS.mac? ? "osx" : "linux"
+
+    system "dotnet", "publish", "src/officecli/officecli.csproj",
+           "--configuration", "Release",
+           "--runtime", "#{os}-#{arch}",
+           "--output", buildpath/"dist"
+
+    if OS.mac?
+      bin.install buildpath/"dist/officecli"
+    else
+      libexec.install buildpath/"dist/officecli"
+      brew_libs = [
+        Formula["brotli"].opt_lib,
+        Formula["icu4c@78"].opt_lib,
+        Formula["openssl@3"].opt_lib,
+      ].join(":")
+      (bin/"officecli").write_env_script libexec/"officecli",
+                                         LD_LIBRARY_PATH: "#{brew_libs}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+    end
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/officecli --version")
+  end
+end


### PR DESCRIPTION
New formula: OfficeCLI 1.0.89 — AI-friendly CLI for Office documents (.docx, .xlsx, .pptx).

- Builds from source with `dotnet => :build` (net10.0, self-contained, single-file, trimmed via csproj defaults).
- Runtime dep on `brotli` (only Homebrew lib the produced binary links to).
- Local verification on arm64_tahoe: `brew style --fix`, `brew audit --strict --online --new`, `brew install --build-from-source`, `brew test` all pass.

After CI passes, add the `pr-pull` label to trigger bottle build/upload.