### PR TITLE
seqcli: build self-contained, drop runtime dotnet dependency

### DIFF
--- a/Formula/seqcli.rb
+++ b/Formula/seqcli.rb
@@ -4,6 +4,7 @@ class Seqcli < Formula
   url "https://github.com/datalust/seqcli/archive/refs/tags/v2025.2.02473.tar.gz"
   sha256 "0e52768d85fb6495c59a30dd308522a2a3c3f38b30985ed21fc3b1c9037ea326"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :stable
@@ -16,26 +17,38 @@ class Seqcli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "4f96353057165c4ad3e17f0b9511a7293399ab3bb3597ae73d5e9b8ce9545235"
   end
 
-  depends_on "dotnet"
+  depends_on "dotnet" => :build
+  depends_on "brotli"
+
+  on_linux do
+    depends_on "icu4c@78"
+    depends_on "openssl@3"
+  end
 
   def install
     ENV["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1"
 
-    dotnet = Formula["dotnet"]
+    system "dotnet", "publish", "src/SeqCli/SeqCli.csproj",
+           "--configuration", "Release",
+           "--use-current-runtime",
+           "--self-contained",
+           "--output", buildpath/"dist",
+           "-p:PublishSingleFile=true",
+           "-p:Version=#{version}"
 
-    args = %W[
-      --configuration Release
-      --framework net#{dotnet.version.major_minor}
-      --output #{libexec}
-      --no-self-contained
-      --use-current-runtime
-      -p:PublishSingleFile=true
-      -p:Version=#{version}
-    ]
+    libexec.install Dir[buildpath/"dist/*"]
 
-    system "dotnet", "publish", "src/SeqCli/SeqCli.csproj", *args
-
-    (bin/"seqcli").write_env_script libexec/"seqcli", DOTNET_ROOT: "${DOTNET_ROOT:-#{dotnet.opt_libexec}}"
+    if OS.mac?
+      bin.install_symlink libexec/"seqcli"
+    else
+      brew_libs = [
+        Formula["brotli"].opt_lib,
+        Formula["icu4c@78"].opt_lib,
+        Formula["openssl@3"].opt_lib,
+      ].join(":")
+      (bin/"seqcli").write_env_script libexec/"seqcli",
+                                      LD_LIBRARY_PATH: "#{brew_libs}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+    end
   end
 
   test do


### PR DESCRIPTION
## Summary
- 仿照 `officecli` 的模式改造 `seqcli`：`dotnet` 降为 `=> :build` 仅构建期依赖，产物运行时不再依赖 `dotnet` formula
- 发布改为 self-contained（`--use-current-runtime --self-contained`），把 .NET 运行时打进产物
- 新增运行期依赖 `brotli`；Linux 额外依赖 `icu4c@78` / `openssl@3`（self-contained .NET 在 Linux 仍需系统 ICU/OpenSSL），并通过 `write_env_script` 注入 `LD_LIBRARY_PATH`
- 因 `SeqCli.csproj` 带 `Content` 资源文件（`BenchCases.json`、`Sample/Templates/*` 等），将整个发布目录装入 `libexec`，macOS 用 `bin.install_symlink`

## Test plan
- [ ] CI: `brew audit` / `brew test`
- [ ] CI: 多平台 bottle 构建
- [ ] 验证 `seqcli` 在无 `dotnet` formula 的环境下可运行