### PR TITLE
zenity-go 0.10.14

### DIFF
--- a/Formula/zenity-go.rb
+++ b/Formula/zenity-go.rb
@@ -1,0 +1,34 @@
+class ZenityGo < Formula
+  desc "Zenity dialogs for Golang, Windows, macOS"
+  homepage "https://pkg.go.dev/github.com/ncruces/zenity"
+  url "https://github.com/ncruces/zenity/archive/refs/tags/v0.10.14.tar.gz"
+  sha256 "10ccfaa5e454048ee6383883f64e510ba98dd440c00e3951e5458a07052ee539"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  conflicts_with "zenity", because: "both install `zenity` binaries"
+
+  def install
+    # The native Linux backend just shells out to the system `zenity`, so on
+    # Linux build the Windows executable instead, for use under WSL. GOARCH is
+    # left to follow the host, so amd64/arm64 map to the matching Windows arch.
+    if OS.linux?
+      ENV["GOOS"] = "windows"
+      system "go", "build", *std_go_args(ldflags: "-s -w", output: libexec/"zenity.exe"), "./cmd/zenity"
+      (bin/"zenity").write_env_script libexec/"zenity.exe", "--unixeol --wslpath", {}
+    else
+      system "go", "build", *std_go_args(ldflags: "-s -w", output: bin/"zenity"), "./cmd/zenity"
+    end
+  end
+
+  test do
+    # A Windows executable cannot run on a non-WSL Linux host, so just check it
+    # was produced; macOS and WSL can actually drive a dialog.
+    if OS.linux? && !OS.wsl?
+      assert_path_exists libexec/"zenity.exe"
+    else
+      pipe_output "#{bin}/zenity --progress --auto-close"
+    end
+  end
+end


### PR DESCRIPTION
New formula: [ncruces/zenity](https://github.com/ncruces/zenity) — pure-Go (no cgo) zenity-compatible dialogs.

## 平台行为
- **macOS**: 原生构建 `bin/zenity`(内部 shell out 给 `osascript`)。
- **Linux**: 由于原生 Linux 后端只是包装系统 `zenity`,这里改为交叉编译 Windows 可执行程序(`GOOS=windows`,`GOARCH` 沿用本机)供 WSL 使用,装到 `libexec/zenity.exe`,并用包装脚本附加 `--unixeol --wslpath`。
- **test**: 非 WSL Linux 仅校验产物存在(无法执行 PE);macOS / WSL 真正驱动一次对话框。

## 验证
- `brew style` / `brew audit --new --strict --online` 通过
- 实测 `go build ./cmd/zenity` 原生 + `GOOS=windows` 交叉编译均成功