### PR TITLE
remindctl 0.3.0

### DIFF
--- a/Formula/remindctl.rb
+++ b/Formula/remindctl.rb
@@ -1,0 +1,28 @@
+class Remindctl < Formula
+  desc "Fast CLI for Apple Reminders"
+  homepage "https://github.com/openclaw/remindctl"
+  url "https://github.com/openclaw/remindctl/archive/refs/tags/v0.3.0.tar.gz"
+  sha256 "360242b73cfca1cde5e5ab6cb8ceef1f91b61b7eae603c287ba56b3d70a24eda"
+  license "MIT"
+
+  depends_on xcode: ["16.0", :build]
+  depends_on :macos
+
+  def install
+    system "bash", "scripts/generate-version.sh"
+    system "swift", "build", "--disable-sandbox", "-c", "release", "--product", "remindctl"
+    bin.install ".build/release/remindctl"
+  end
+
+  def caveats
+    <<~EOS
+      remindctl needs Reminders access.
+      System Settings > Privacy & Security > Reminders
+    EOS
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/remindctl --version")
+    assert_match "Manage Apple Reminders", shell_output("#{bin}/remindctl --help")
+  end
+end


### PR DESCRIPTION
移植 steipete/tap（已迁移至 openclaw org）的 `remindctl` 到本 tap，改为**本地源码构建**而非下载预编译二进制。

- Swift Package Manager 项目，`swift build --disable-sandbox -c release`
- 构建前 `scripts/generate-version.sh` 生成 `Version.swift` 与构建必需的 `Info.plist`
- `depends_on macos: :sonoma` + `depends_on xcode: :build`
- 保留原 formula 骨架（desc / caveats / test）

本地验证：`brew style` / `brew audit --strict --online --new` / `brew livecheck`（默认 Git 策略识别 0.3.0）/ `brew install --build-from-source`（19s 构建成功）/ `brew test` 均通过。