### PR TITLE
imsg 0.11.0

### DIFF
--- a/Formula/imsg.rb
+++ b/Formula/imsg.rb
@@ -1,0 +1,52 @@
+class Imsg < Formula
+  desc "Send and read iMessage / SMS from the terminal"
+  homepage "https://github.com/openclaw/imsg"
+  url "https://github.com/openclaw/imsg/archive/refs/tags/v0.11.0.tar.gz"
+  sha256 "60a4a75d8708769d0099a6bfa7626446dff575e0f21f4c973c9defc4b245572b"
+  license "MIT"
+
+  depends_on xcode: ["16.0", :build]
+  depends_on :macos
+
+  def install
+    system "bash", "scripts/generate-version.sh"
+    system "swift", "package", "--disable-sandbox", "resolve"
+    system "bash", "scripts/patch-deps.sh"
+    system "swift", "build", "--disable-sandbox", "-c", "release", "--product", "imsg"
+
+    libexec.install ".build/release/imsg"
+    Dir[".build/release/*.bundle"].each { |bundle| libexec.install bundle }
+
+    if Hardware::CPU.arm?
+      system ENV.cc, "-dynamiclib", "-arch", "arm64e", "-fobjc-arc",
+             "-Wno-arc-performSelector-leaks",
+             "-framework", "Foundation", "-framework", "AppKit",
+             "-o", "imsg-bridge-helper.dylib",
+             "Sources/IMsgHelper/IMsgInjected.m"
+      libexec.install "imsg-bridge-helper.dylib"
+    end
+
+    bin.write_exec_script libexec/"imsg"
+  end
+
+  def caveats
+    <<~EOS
+      imsg needs Full Disk Access to read the Messages database.
+
+      To grant permission:
+      1. Open System Settings > Privacy & Security > Full Disk Access
+      2. Enable access for your Terminal application
+
+      To send messages, allow Terminal to control Messages.app:
+      System Settings > Privacy & Security > Automation
+
+      Advanced IMCore bridge features also require SIP disabled. The formula
+      builds and installs the bridge helper automatically on Apple Silicon.
+    EOS
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/imsg --version")
+    assert_match "Send and read iMessage", shell_output("#{bin}/imsg --help")
+  end
+end


### PR DESCRIPTION
移植 steipete/tap（已迁移至 openclaw org）的 `imsg` 到本 tap，改为**本地源码构建**而非下载预编译二进制。

构建链（对齐上游 Makefile `build` target）：
- `scripts/generate-version.sh` 生成 `Version.swift` 与构建必需的 `Info.plist`
- `swift package --disable-sandbox resolve` → `scripts/patch-deps.sh`（补丁 SQLite.swift / PhoneNumberKit）
- `swift build --disable-sandbox -c release --product imsg`
- 保留原骨架：`imsg` 与 PhoneNumberKit/SQLite 的 `*.bundle` 资源装入 `libexec`，`bin.write_exec_script` 包装
- Apple Silicon 上用 `clang` 从 `Sources/IMsgHelper/IMsgInjected.m` 现编 `imsg-bridge-helper.dylib`（arm64e 注入库）装入 `libexec`

本地验证：`brew style` / `brew audit --strict --online --new`（含已安装 keg 的 Mach-O 检查，dylib 为 arm64e + TWOLEVEL 命名空间，无需豁免）/ `brew livecheck`（默认 Git 策略识别 0.11.0）/ `brew install --build-from-source`（41s 构建成功）/ `brew test` 均通过。