### PR TITLE
marksman-bundled 2026-02-08

### DIFF
--- a/Formula/marksman-bundled.rb
+++ b/Formula/marksman-bundled.rb
@@ -1,0 +1,79 @@
+class MarksmanBundled < Formula
+  desc "Language Server Protocol for Markdown"
+  homepage "https://github.com/artempyanykh/marksman"
+  url "https://github.com/artempyanykh/marksman/archive/refs/tags/2026-02-08.tar.gz"
+  sha256 "a3ba5f8ef5be5d7ede2ec5ae9f303d2d776f476734ff66254be8e6df0e0f090e"
+  license "MIT"
+  head "https://github.com/artempyanykh/marksman.git", branch: "main"
+
+  depends_on "dotnet@9" => :build # https://github.com/artempyanykh/marksman/pull/446
+  depends_on "brotli"
+
+  on_linux do
+    depends_on "icu4c@78"
+    depends_on "libunwind"
+    depends_on "openssl@3"
+    depends_on "zlib-ng-compat"
+  end
+
+  conflicts_with "marksman", because: "both install a `marksman` binary"
+
+  def install
+    ENV["DOTNET_CLI_TELEMETRY_OPTOUT"] = "true"
+
+    dotnet = Formula["dotnet@9"]
+    args = %W[
+      --configuration Release
+      --framework net#{dotnet.version.major_minor}
+      --self-contained
+      --output #{libexec}
+      --use-current-runtime
+      -p:PublishSingleFile=true
+      -p:PublishTrimmed=true
+      -p:TrimMode=partial
+      -p:DebugType=embedded
+      -p:EnableCompressionInSingleFile=true
+    ]
+    args << "-p:VersionString=#{version}" if build.stable?
+
+    system "dotnet", "publish", "Marksman/Marksman.fsproj", *args
+
+    if OS.mac?
+      bin.install_symlink libexec/"marksman"
+    else
+      brew_libs = [
+        Formula["brotli"].opt_lib,
+        Formula["icu4c@78"].opt_lib,
+        Formula["openssl@3"].opt_lib,
+      ].join(":")
+      (bin/"marksman").write_env_script libexec/"marksman",
+                                        LD_LIBRARY_PATH: "#{brew_libs}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+    end
+  end
+
+  test do
+    require "open3"
+
+    json = <<~JSON
+      {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+          "rootUri": null,
+          "capabilities": {}
+        }
+      }
+    JSON
+
+    ENV["DOTNET_SYSTEM_GLOBALIZATION_INVARIANT"] = "1"
+
+    Open3.popen3(bin/"marksman", "server") do |stdin, stdout|
+      stdin.write "Content-Length: #{json.size}\r\n\r\n#{json}"
+
+      sleep 3
+
+      assert_match(/^Content-Length: \d+/i, stdout.readline)
+    end
+  end
+end


### PR DESCRIPTION
Port homebrew/core's `marksman` as a **self-contained** build, renamed to `marksman-bundled`.

Core builds with `--no-self-contained`, so it depends on the `dotnet@9` formula at runtime (`dotnet@9` is keg-only and itself EOL-deprecated). This build bundles the .NET 9 runtime into the binary instead — `dotnet@9` becomes a `:build`-only dependency.

Build mirrors upstream's own `Makefile` release recipe (trim + compress), so the binary is ~22MB rather than ~89MB:
`--self-contained -p:PublishTrimmed=true -p:TrimMode=partial -p:EnableCompressionInSingleFile=true -p:PublishSingleFile=true`, plus `-p:VersionString`.

- `conflicts_with "marksman"` (both install a `marksman` binary).
- Linux native libs (icu4c@78 / openssl@3 / brotli) wired via LD_LIBRARY_PATH env script.
- Dropped core's `deprecate!`/`disable!` (no longer tied to the dotnet@9 formula lifecycle).
- Ported core's LSP `initialize` handshake test verbatim.

Verified locally: build + test + linkage + audit --new all green.