### PR TITLE
oracle-instantclient 23.26.2.0.0

### DIFF
--- a/Formula/oracle-instantclient.rb
+++ b/Formula/oracle-instantclient.rb
@@ -1,16 +1,8 @@
-require "formula_installer"
-
-FormulaInstaller.class_eval do
-  define_method(:fix_dynamic_linkage) do |_keg|
-    nil
-  end
-end
-
 class OracleInstantclient < Formula
   desc "Instant Client for Oracle"
   homepage "https://www.oracle.com/database/technologies/instant-client.html"
-  url "https://download.oracle.com/otn_software/mac/instantclient/2326100/instantclient-basic-macos.arm64-23.26.1.0.0.dmg"
-  sha256 "5dc67a7e1cccd0a01d5bf53d7cf13b56f00999e3c2c1a309d8600cd766d80b41"
+  url "https://download.oracle.com/otn_software/mac/instantclient/2326200/instantclient-basic-macos.arm64-23.26.2.0.0.dmg"
+  sha256 "c3c4fce37a557192322717c1a8422fe098fc829a41f382f57a288b24ad6ba11e"
   license :cannot_represent
 
   livecheck do
@@ -21,56 +13,53 @@ class OracleInstantclient < Formula
   depends_on arch: :arm64
   depends_on :macos
 
+  # The shipped binaries are signed by Oracle and load each other through
+  # `@rpath`. Rewriting the dylib IDs would force an ad-hoc re-signature, and
+  # dyld then refuses to map them into the untouched, Oracle-signed executables
+  # ("mapping process and mapped file (non-platform) have different Team IDs").
+  preserve_rpath
+
   resource "sqlplus" do
-    url "https://download.oracle.com/otn_software/mac/instantclient/2326100/instantclient-sqlplus-macos.arm64-23.26.1.0.0.dmg"
-    sha256 "db973a9d2a672b462333feda091c8b2e2defe7aa2a2f4b266a8f36ee356d979e"
+    url "https://download.oracle.com/otn_software/mac/instantclient/2326200/instantclient-sqlplus-macos.arm64-23.26.2.0.0.dmg"
+    sha256 "c3b10537194a5267a3ed18d09fddae1f864191e0de25ad78042940bb82496294"
   end
 
   resource "sdk" do
-    url "https://download.oracle.com/otn_software/mac/instantclient/2326100/instantclient-sdk-macos.arm64-23.26.1.0.0.dmg"
-    sha256 "6a101a8c6651a76055a3222b1860dcdabdc7c14c82759daa8ca11c5d13c8d1eb"
+    url "https://download.oracle.com/otn_software/mac/instantclient/2326200/instantclient-sdk-macos.arm64-23.26.2.0.0.dmg"
+    sha256 "5ee0dffe7ff0ac55eea198ef69681cc729fc7fdf17cc9089f8bfd5d93c51413e"
   end
 
   resource "precompiler" do
-    url "https://download.oracle.com/otn_software/mac/instantclient/2326100/instantclient-precomp-macos.arm64-23.26.1.0.0.dmg"
-    sha256 "d5fc90ffa7e36e55a97154737debabf618cb3fe7f90f4f0e909e538afe3721ea"
+    url "https://download.oracle.com/otn_software/mac/instantclient/2326200/instantclient-precomp-macos.arm64-23.26.2.0.0.dmg"
+    sha256 "aa32fe5ce1d4f1041bdfa73f00996c045d752718ea88be9428d54030cf52d349"
   end
 
   def install
-    dir = "instantclient_#{version.major}_#{version.minor}"
     excluded = %w[INSTALL_IC_README.txt install_ic.sh]
 
-    cd dir do
-      pkgetc.install "network"
-      libexec.install Dir["*"] - [*excluded, "network"]
-      libexec.install_symlink pkgetc/"network"
-    end
+    pkgetc.install "network"
+    libexec.install Dir["*"] - [*excluded, "network"]
+    libexec.install_symlink pkgetc/"network"
 
     resource("sqlplus").stage do
-      cd dir do
-        libexec.install Dir["*"] - excluded
-      end
+      libexec.install Dir["*"] - excluded
     end
 
     resource("sdk").stage do
-      cd dir do
-        libexec.install Dir["*"] - excluded
-      end
+      libexec.install Dir["*"] - excluded
     end
 
     resource("precompiler").stage do
-      cd dir do
-        pkgetc.install "precomp"
-        libexec.install Dir["*"] - [*excluded, "sdk", "precomp"]
-        libexec.install_symlink pkgetc/"precomp"
-        (libexec/"sdk").install "sdk/proc"
-        (libexec/"sdk/demo").install Dir["sdk/demo/*"]
-        (libexec/"sdk/include").install Dir["sdk/include/*"]
-      end
+      pkgetc.install "precomp"
+      libexec.install Dir["*"] - [*excluded, "sdk", "precomp"]
+      libexec.install_symlink pkgetc/"precomp"
+      (libexec/"sdk").install "sdk/proc"
+      (libexec/"sdk/demo").install Dir["sdk/demo/*"]
+      (libexec/"sdk/include").install Dir["sdk/include/*"]
     end
 
     env = {
-      ORACLE_HOME: "${ORACCLE_HOME:-#{opt_libexec}}",
+      ORACLE_HOME: "${ORACLE_HOME:-#{opt_libexec}}",
       NLS_LANG:    "${NLS_LANG:-SIMPLIFIED CHINESE_CHINA.AL32UTF8}",
     }
     (bin/"sqlplus").write_env_script opt_libexec/"sqlplus", env


### PR DESCRIPTION
Publish `oracle-instantclient` 23.26.2.0.0.

- Upstream flattened the DMG layout in 23.26.2.0.0 (no more `instantclient_23_26/` subdirectory), so the `cd dir` wrappers in `install` are gone.
- Replaced the `FormulaInstaller#fix_dynamic_linkage` monkey patch with the `preserve_rpath` DSL. Rewriting the `@rpath` dylib IDs forced an ad-hoc re-signature, which made dyld reject the libraries when loaded by the untouched Oracle-signed executables ("different Team IDs").
- Fixed a typo: `${ORACCLE_HOME:-…}` -> `${ORACLE_HOME:-…}`.