### PR TITLE
sing-box-ref1nd 1.14.0-beta.8-reF1nd-moonfruit

### DIFF
--- a/Formula/sing-box-ref1nd.rb
+++ b/Formula/sing-box-ref1nd.rb
@@ -1,15 +1,15 @@
 class SingBoxRef1nd < Formula
   desc "Universal proxy platform"
-  homepage "https://github.com/reF1nd/sing-box"
-  url "https://github.com/reF1nd/sing-box/archive/refs/tags/v1.14.0-beta.7-reF1nd.tar.gz"
-  version "1.14.0-beta.7-reF1nd"
-  sha256 "8819d541a62332793f7759658f2f44d770b0922af9496208b7c2a0254d137ed4"
+  homepage "https://github.com/moonfruit/sing-box"
+  url "https://github.com/moonfruit/sing-box/archive/refs/tags/v1.14.0-beta.8-reF1nd-moonfruit.tar.gz"
+  version "1.14.0-beta.8-reF1nd-moonfruit"
+  sha256 "4018836c106c021b66a36ca99f4d31e4032b5de6c60aecea3e41c7dc542d1580"
   license "GPL-3.0-or-later"
-  head "https://github.com/reF1nd/sing-box.git", branch: "reF1nd-dev-next"
+  head "https://github.com/moonfruit/sing-box.git", branch: "moonfruit"
 
   livecheck do
     url :stable
-    regex(/^v(\d(?:\.\d+)+(-\w+(?:\.\d+)?)?-reF1nd(?:\.\d+)?)$/i)
+    regex(/^v(\d(?:\.\d+)+(-\w+(?:\.\d+)?)?-reF1nd(?:\.\d+)?-moonfruit(?:\.\d+)?)$/i)
   end
 
   bottle do


### PR DESCRIPTION
把 formula 的来源从 `reF1nd/sing-box` 切到 `moonfruit/sing-box`。

后者是 reF1nd 的 fork，在其之上带一个上游不会接收的 patch —— mDNS transport 原本只在调用方 deadline 到期的那一刻才组装合并响应，于是 Linux 上每次 `.local` 解析都要阻塞满整个 DNS 超时，客户端根本收不到答案。

该 fork 里的自动化负责发布：每次 reF1nd 出新 tag 就把 patch rebase 上去并重新打 tag，所以版本串里保留了它所基于的上游版本号（`1.14.0-beta.8-reF1nd-moonfruit` 基于 `v1.14.0-beta.8-reF1nd`）。

改动四处：`homepage` / `url` / `head` 指向 fork，`livecheck` 正则追加 `-moonfruit(?:\.\d+)?`。`install` / `test` / `service` / `bottle root_url` 均未改动。

- `brew style`：无 offense
- `brew livecheck`：正确识别 `1.14.0-beta.8-reF1nd-moonfruit`
- 版本序：`1.14.0-beta.7-reF1nd` < `1.14.0-beta.8-reF1nd-moonfruit`，可正常 `brew upgrade`