### PR TITLE
sfm@beta: rename from sfm@alpha

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ This is a personal Homebrew third-party tap (`moonfruit/tap`) containing Formula
 - `audit_exceptions/` — JSON files suppressing specific `brew audit` warnings
   - `github_prerelease_allowlist.json` — JSON array of formula/cask names allowed to track prereleases
   - `flat_namespace_allowlist.json` — JSON object `{ "<name>": "any" | ["dylib", ...] }` for casks with non-relocatable Mach-O
+- `cask_renames.json` — JSON object `{ "<old-token>": "<new-token>" }` mapping renamed casks so the old token still resolves (formulae use `formula_renames.json`)
 
 ## Reference Implementations
 
@@ -77,7 +78,7 @@ Bottles are hosted on GitHub Container Registry under `ghcr.io/v2/moonfruit/bott
 
 - 双架构以 `arch arm: "...", intel: "..."` + `sha256 arm:, intel:` 表达；URL 中用 `#{arch}`
 - 字体 Cask 命名为 `font-*`，参考 `Casks/font-source-han-*`、`Casks/font-pinyin-*`
-- `.pkg` 安装必须配 `uninstall pkgutil:`；带后台进程再加 `quit:`，登录项加 `login_item:`（见 `sfm@alpha.rb`）
+- `.pkg` 安装必须配 `uninstall pkgutil:`；带后台进程再加 `quit:`，登录项加 `login_item:`（见 `sfm@beta.rb`）
 - `zap trash: [...]` 列出 `~/Library/...` 残留路径
 - `verified:` 用于非 GitHub releases 域或自定义 URL；`url "..." , verified: "github.com/<org>/<repo>/"` 是常见写法
 

--- a/Casks/sfm@beta.rb
+++ b/Casks/sfm@beta.rb
@@ -1,13 +1,12 @@
-cask "sfm@alpha" do
+cask "sfm@beta" do
   arch arm: "Apple", intel: "Intel"
 
   version "1.14.0-beta.9"
   sha256 arm:   "1da76d61342585092e9bd3bfcb04c46b60f3bdd14f27852267e9cd4d950dc611",
          intel: "ece557fda848c837348ebd4b91bcc036ec42e35aed50a08b25700102a1aac3c1"
 
-  url "https://github.com/SagerNet/sing-box/releases/download/v#{version}/SFM-#{version}-#{arch}.pkg",
-      verified: "github.com/SagerNet/sing-box/"
-  name "SFM alpha"
+  url "https://github.com/SagerNet/sing-box/releases/download/v#{version}/SFM-#{version}-#{arch}.pkg"
+  name "SFM beta"
   desc "Standalone client for sing-box, the universal proxy platform"
   homepage "https://sing-box.sagernet.org/"
 

--- a/README.md
+++ b/README.md
@@ -290,9 +290,9 @@ brew untap moonfruit/tap        # remove the tap entirely
 - **Repository**: N/A
 - **Description**: 3D modeling software
 
-#### 🌐 sfm@alpha
+#### 🌐 sfm@beta
 
-- **Homepage**: [SFM alpha](https://sing-box.sagernet.org/)
+- **Homepage**: [SFM beta](https://sing-box.sagernet.org/)
 - **Repository**: [SagerNet/sing-box](https://github.com/SagerNet/sing-box)
 - **Description**: Standalone client for sing-box, the universal proxy platform
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -288,9 +288,9 @@ brew untap moonfruit/tap        # 完全移除 tap
 - **仓库**：N/A
 - **简介**：3D 建模软件
 
-#### 🌐 sfm@alpha
+#### 🌐 sfm@beta
 
-- **主页**：[SFM alpha](https://sing-box.sagernet.org/)
+- **主页**：[SFM beta](https://sing-box.sagernet.org/)
 - **仓库**：[SagerNet/sing-box](https://github.com/SagerNet/sing-box)
 - **简介**：sing-box 通用代理平台的独立客户端
 

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -1,3 +1,3 @@
 {
-  "sfm@alpha": "any"
+  "sfm@beta": "any"
 }

--- a/cask_renames.json
+++ b/cask_renames.json
@@ -1,0 +1,3 @@
+{
+  "sfm@alpha": "sfm@beta"
+}


### PR DESCRIPTION
Rename the `sfm@alpha` cask to `sfm@beta`, matching the upstream SFM prerelease channel (current version `1.14.0-beta.9`).

- rename `Casks/sfm@alpha.rb` → `Casks/sfm@beta.rb`, cask token and `name` updated
- add `cask_renames.json` so the old `sfm@alpha` token still resolves
- drop the deprecated `verified:` url parameter
- update `audit_exceptions/github_prerelease_allowlist.json`, README listings and the `CLAUDE.md` reference